### PR TITLE
use docker official image instead of gcp docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,13 @@ shell:
 bash:
 	$(DOCKER_EXEC) bash
 
-deploy:
-	$(info Deploying [$(REPO_NAME):$(SHORT_SHA)] to [$(PROJECT_ID)])
-	gcloud builds submit --substitutions REPO_NAME=$(REPO_NAME),SHORT_SHA=$(SHORT_SHA)
+gcp-test:
+	$(info Running GCP Test Build [$(REPO_NAME):$(SHORT_SHA)] to [$(PROJECT_ID)])
+	gcloud builds submit --substitutions REPO_NAME=$(REPO_NAME),SHORT_SHA=$(SHORT_SHA) --config=./cloudbuild/test.yml
+
+gcp-deploy:
+	$(info Running GCP Deploy Build [$(REPO_NAME):$(SHORT_SHA)] to [$(PROJECT_ID)])
+	gcloud builds submit --substitutions REPO_NAME=$(REPO_NAME),SHORT_SHA=$(SHORT_SHA) --config=./cloudbuild/deploy.yml
 
 frontend-prod:
 	docker run --rm -it -v $(shell pwd)/frontend:/app $(shell docker build ./frontend -q --target=prod)

--- a/cloudbuild/deploy.yml
+++ b/cloudbuild/deploy.yml
@@ -2,20 +2,20 @@ steps:
 # --- Build ---
 
 # Backend / Build Docker container
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'build-backend'
+- name: docker:20.10
+  id: 'backend-build'
   args: ['build', '-t', 
           'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA', './backend',
           '--target=prod']
 
 # Backend / Push container to Google Artifact Registry
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'push-backend'
+- name: docker:20.10
+  id: 'backend-push'
   args: ['push', 'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA']
 
 # Frontend / Install dependencies
 - name: node:16.10
-  id: 'init-frontend'
+  id: 'frontend-init'
   entrypoint: npm
   args: ['install']
   dir: 'frontend/'
@@ -23,7 +23,7 @@ steps:
 
 # Frontend / Build
 - name: node:16.10
-  id: 'build-frontend'
+  id: 'frontend-build'
   entrypoint: npm
   args: ['run', 'build']
   env:
@@ -34,31 +34,35 @@ steps:
 
 # Backend / Deploy to Cloud Run
 - name: google/cloud-sdk
-  id: 'deploy-backend'
+  id: 'backend-deploy'
   args: ['gcloud', 'run', 'deploy', 'wordbrew-api', 
           '--image=gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA',
           '--region', 'us-west2', '--platform', 'managed', 
           '--allow-unauthenticated', '--port', '8000']
-  waitFor: ['push-backend', 'build-frontend']
+  waitFor: ['backend-push', 'frontend-build']
 
 # Frontend / Copy to storage bucket with gzip
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: 'frontend-deploy'
   entrypoint: gsutil
   args: ['-m', 'cp', '-r', '-z', 'css,js', './frontend/build/*', 'gs://${_BUCKET_NAME}']
   waitFor: ['deploy-backend']
 
 # Frontend / Remove any files that no longer exist in build
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: 'frontend-remove-old'
   entrypoint: gsutil
   args: ['-m', 'rsync', '-r', '-i', '-d', './frontend/build', 'gs://${_BUCKET_NAME}']
 
 # Frontend / Set cache to 1yr on all files
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: 'frontend-set-cache-all'
   entrypoint: gsutil
   args: ['-m', 'setmeta', '-h', 'Cache-Control:max-age=31536000', 'gs://${_BUCKET_NAME}/**']
 
 # Frontend / Set no cache on html files
 - name: 'gcr.io/cloud-builders/gcloud'
+  id: 'frontend-set-cache-html'
   entrypoint: gsutil
   args: ['-m', 'setmeta', '-h', 'Cache-Control:no-store', 'gs://${_BUCKET_NAME}/**.html']
 

--- a/cloudbuild/test.yml
+++ b/cloudbuild/test.yml
@@ -1,8 +1,8 @@
 steps:
 
 # Backend / Build Docker container
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'test-build-backend'
+- name: docker:20.10
+  id: 'backend-build-and-test'
   args: ['build', '-t', 
           'gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA', './backend',
           '--target=test']


### PR DESCRIPTION
Use the official "docker in docker" image to specify version, so the same version can be used everywhere (local development and in cloud build). This was a result of discovering that BuildKit became the default in Docker 20+ (which I was using locally), but it was NOT the default in Docker 19 and earlier (which is what the GCP docker image uses).